### PR TITLE
allow chart to be initialized without width() or height() calls

### DIFF
--- a/d3.chart.base.js
+++ b/d3.chart.base.js
@@ -6,8 +6,11 @@ d3.chart("BaseChart", {
   initialize: function() {
 
     // setup some reasonable defaults
-    this._width  = this.base.attr("width") || 200;
-    this._height = this.base.attr("height") || 200;
+    this._height = 200;
+    this.base.attr('height', this._height);
+
+    this._width = 200;
+    this.base.attr('width', this._width);
 
   },
 

--- a/dist/d3.chart.base.js
+++ b/dist/d3.chart.base.js
@@ -1,0 +1,67 @@
+/*! d3.chart.base - v0.1.0
+ *  License: MIT Expat
+ *  Date: 2013-06-07
+ */
+d3.chart("BaseChart", {
+  initialize: function() {
+
+    // setup some reasonable defaults
+    this._height = 200;
+    this.base.attr('height', this._height);
+
+    this._width = 200;
+    this.base.attr('width', this._width);
+
+  },
+
+  width: function(newWidth) {
+    if (arguments.length === 0) {
+      return this._width;
+    }
+
+    var oldWidth = this._width;
+
+    this._width = newWidth;
+
+    // only if the width actually changed:
+    if (this._width !== oldWidth) {
+
+      // set higher container width
+      this.base.attr("width", this._width);
+
+      // trigger a change event
+      this.trigger("change:width", this._width, oldWidth);
+
+      // redraw if we saved the data on the chart
+      if (this.data) {
+        this.draw(this.data);
+      }
+    }
+
+    // always return the chart, for chaining magic.
+    return this;
+  },
+
+  height: function(newHeight) {
+    if (arguments.length === 0) {
+      return this._height;
+    }
+
+    var oldHeight = this._height;
+
+    this._height = newHeight;
+
+    if (this._height !== oldHeight) {
+
+      this.base.attr("height", this._height);
+
+      this.trigger("change:height", this._height, oldHeight);
+
+      if (this.data) {
+        this.draw(this.data);
+      }
+    }
+
+    return this;
+  }
+});

--- a/dist/d3.chart.base.min.js
+++ b/dist/d3.chart.base.min.js
@@ -1,0 +1,5 @@
+/*! d3.chart.base - v0.1.0
+ *  License: MIT Expat
+ *  Date: 2013-06-07
+ */
+d3.chart("BaseChart",{initialize:function(){this._height=200,this.base.attr("height",this._height),this._width=200,this.base.attr("width",this._width)},width:function(t){if(0===arguments.length)return this._width;var h=this._width;return this._width=t,this._width!==h&&(this.base.attr("width",this._width),this.trigger("change:width",this._width,h),this.data&&this.draw(this.data)),this},height:function(t){if(0===arguments.length)return this._height;var h=this._height;return this._height=t,this._height!==h&&(this.base.attr("height",this._height),this.trigger("change:height",this._height,h),this.data&&this.draw(this.data)),this}});

--- a/src/base.js
+++ b/src/base.js
@@ -2,8 +2,11 @@ d3.chart("BaseChart", {
   initialize: function() {
 
     // setup some reasonable defaults
-    this._width  = this.base.attr("width") || 200;
-    this._height = this.base.attr("height") || 200;
+    this._height = 200;
+    this.base.attr('height', this._height);
+
+    this._width = 200;
+    this.base.attr('width', this._width);
 
   },
 


### PR DESCRIPTION
This way we can do something like

```
var area = d3.select('#vis')
    .append('svg')
    .chart('myChart');
```
