### PR TITLE
Base charts fail init on IE9 due to CSS 'px' attribute requirement

### DIFF
--- a/d3.chart.base.js
+++ b/d3.chart.base.js
@@ -175,8 +175,8 @@
       chart._height = _toNumFromPx(_style.call(chart, "height")) || 200;
 
       // make sure container height and width are set.
-      _initAttr.call(this, "_width", "width", 200);
-      _initAttr.call(this, "_height", "height", 200);
+      _initAttr.call(this, "_width", "width", "200px");
+      _initAttr.call(this, "_height", "height", "200px");
 
       // bind to winow resize end
       window.addEventListener("resize", _debounce(function() {


### PR DESCRIPTION
In IE9, d3.chart.base charts fail to initialize with the following error:

`Invalid argument. d3.js, line 32 character 7`

This corresponds to the following method in d3:

```
d3_style_prototype.setProperty = function(name, value, priority) {
  d3_style_setProperty.call(this, name, value + "", priority);
};
```

Digging into this further, the issue is because height and width CSS styles are being set without a 'px' suffix.   The attached pull request fixes this issue. Charts are initialized with width/height "200px" / "200px".
